### PR TITLE
Replace nested settings dict with dotted settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .github/ export-ignore
 .gitattributes export-ignore
+sublime-package.json linguist-language=jsonc

--- a/LSP-julia.sublime-settings
+++ b/LSP-julia.sublime-settings
@@ -35,67 +35,34 @@
     "languageId": "julia",
     "scopes": ["source.julia"],
     "syntaxes": ["Packages/Julia/Julia.sublime-syntax"],
-    // "settings": {
-    //     "julia.format.calls": true,      // Format function calls.
-    //     "julia.format.comments": true,   // Format comments.
-    //     "julia.format.curly": true,      // Format braces.
-    //     "julia.format.docs": true,       // Format inline documentation.
-    //     "julia.format.indent": 4,        // Indent size for formatting.
-    //     "julia.format.indents": true,    // Format file indents.
-    //     "julia.format.iterOps": true,    // Format loop iterators.
-    //     "julia.format.keywords": true,   // Ensure single spacing following keywords.
-    //     "julia.format.kwarg": "none",    // Format whitespace around function keyword arguments. Valid values: "none", "single", "off"
-    //     "julia.format.lineends": true,   // [undocumented]
-    //     "julia.format.ops": true,        // Format whitespace around operators.
-    //     "julia.format.tuples": true,     // Format tuples.
-    //     "julia.lint.call": true,         // This compares call signatures against all known methods for the called function. Calls with too many or too few arguments, or unknown keyword parameters are highlighted.
-    //     "julia.lint.constif": true,      // Check for constant conditionals in if statements that result in branches never being reached.
-    //     "julia.lint.datadecl": true,     // Check variables used in type declarations are datatypes.
-    //     "julia.lint.disabledDirs": [     // Specifies sub-directories in a package directory where only basic linting is. This drastically lowers the chance for false positives.
-    //         "docs",
-    //         "test"
-    //     ],
-    //     "julia.lint.iter": true,         // Check iterator syntax of loops. Will identify, for example, attempts to iterate over single values.
-    //     "julia.lint.lazy": true,         // Check for deterministic lazy boolean operators.
-    //     "julia.lint.missingrefs": "all", // Highlight unknown symbols. The `symbols` option will not mark unknown fields. Valid values: "all", "symbols", "none"
-    //     "julia.lint.modname": true,      // Check submodule names do not shadow their parent's name.
-    //     "julia.lint.nothingcomp": true,  // Check for use of `==` rather than `===` when comparing against `nothing`.
-    //     "julia.lint.pirates": true,      // Check for type piracy - the overloading of external functions with methods specified for external datatypes. 'External' here refers to imported code.
-    //     "julia.lint.run": true,          // Run the linter on active files.
-    //     "julia.lint.typeparam": true,    // Check parameters declared in `where` statements or datatype declarations are used.
-    //     "julia.lint.useoffuncargs": true // Check that all declared arguments are used within the function body.
-    // }
     "settings": {
-        "julia": {
-            "format": {
-                "calls": true,
-                "comments": true,
-                "curly": true,
-                "docs": true,
-                "indent": 4,
-                "indents": true,
-                "iterOps": true,
-                "keywords": true,
-                "kwarg": "none",
-                "lineends": true,
-                "ops": true,
-                "tuples": true
-            },
-            "lint": {
-                "call": true,
-                "constif": true,
-                "datadecl": true,
-                "disabledDirs": ["docs", "test"],
-                "iter": true,
-                "lazy": true,
-                "missingrefs": "all",
-                "modname": true,
-                "nothingcomp": true,
-                "pirates": true,
-                "run": true,
-                "typeparam": true,
-                "useoffuncargs": true
-            }
-        }
+        "julia.format.calls": true,      // Format function calls.
+        "julia.format.comments": true,   // Format comments.
+        "julia.format.curly": true,      // Format braces.
+        "julia.format.docs": true,       // Format inline documentation.
+        "julia.format.indent": 4,        // Indent size for formatting.
+        "julia.format.indents": true,    // Format file indents.
+        "julia.format.iterOps": true,    // Format loop iterators.
+        "julia.format.keywords": true,   // Ensure single spacing following keywords.
+        "julia.format.kwarg": "none",    // Format whitespace around function keyword arguments. Valid values: "none", "single", "off"
+        "julia.format.lineends": true,   // [undocumented]
+        "julia.format.ops": true,        // Format whitespace around operators.
+        "julia.format.tuples": true,     // Format tuples.
+        "julia.lint.call": true,         // This compares call signatures against all known methods for the called function. Calls with too many or too few arguments, or unknown keyword parameters are highlighted.
+        "julia.lint.constif": true,      // Check for constant conditionals in if statements that result in branches never being reached.
+        "julia.lint.datadecl": true,     // Check variables used in type declarations are datatypes.
+        "julia.lint.disabledDirs": [     // Specifies sub-directories in a package directory where only basic linting is. This drastically lowers the chance for false positives.
+            "docs",
+            "test"
+        ],
+        "julia.lint.iter": true,         // Check iterator syntax of loops. Will identify, for example, attempts to iterate over single values.
+        "julia.lint.lazy": true,         // Check for deterministic lazy boolean operators.
+        "julia.lint.missingrefs": "all", // Highlight unknown symbols. The `symbols` option will not mark unknown fields. Valid values: "all", "symbols", "none"
+        "julia.lint.modname": true,      // Check submodule names do not shadow their parent's name.
+        "julia.lint.nothingcomp": true,  // Check for use of `==` rather than `===` when comparing against `nothing`.
+        "julia.lint.pirates": true,      // Check for type piracy - the overloading of external functions with methods specified for external datatypes. 'External' here refers to imported code.
+        "julia.lint.run": true,          // Run the linter on active files.
+        "julia.lint.typeparam": true,    // Check parameters declared in `where` statements or datatype declarations are used.
+        "julia.lint.useoffuncargs": true // Check that all declared arguments are used within the function body.
     }
 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -1,0 +1,204 @@
+{
+  "contributions": {
+    "settings": [
+      {
+        "file_patterns": ["/LSP-julia.sublime-settings"],
+        "schema": {
+          "properties": {
+            "julia_executable_path": {
+              "description": "Full path to the Julia executable (including the file)",
+              "type": "string",
+              "default": ""
+            },
+            "sysimage_path": {
+              "description": "Full path to the sysimage used to run the language server (including the file)",
+              "type": "string",
+              "default": ""
+            },
+            "repl_env_variables": {
+              "description": "Additional environmental variables for the Julia REPL",
+              "type": "object",
+              "properties": {
+                "JULIA_NUM_THREADS": {
+                  "description": "Maximum number of threads available to the Julia REPL",
+                  "type": "string",
+                  "default": "4"
+                }
+              }
+            },
+            "show_environment_status": {
+              "description": "Show name of the active Julia environment in the status bar",
+              "type": "boolean",
+              "default": true
+            },
+            "auto_change_environment": {
+              "description": "Automatically change the active Julia environment when server initializes",
+              "type": "boolean",
+              "default": true
+            },
+            "command": {
+              "markdownDescription": "Command to run the Julia language server\n\n*Should not be edited manually!*",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "languageId": {
+              "type": "string"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "syntaxes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "settings": {
+              "description": "Language server configurations",
+              "type": "object",
+              // @see https://github.com/julia-vscode/julia-vscode/blob/master/package.json
+              "properties": {
+                "julia.format.calls": {
+                  "markdownDescription": "Format function calls.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.comments": {
+                  "markdownDescription": "Format comments.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.curly": {
+                  "markdownDescription": "Format braces.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.docs": {
+                  "markdownDescription": "Format inline documentation.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.indent": {
+                  "markdownDescription": "Indent size for formatting.",
+                  "type": "integer",
+                  "default": 4
+                },
+                "julia.format.indents": {
+                  "markdownDescription": "Format file indents.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.iterOps": {
+                  "markdownDescription": "Format loop iterators.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.keywords": {
+                  "markdownDescription": "Ensure single spacing following keywords.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.kwarg": {
+                  "markdownDescription": "Format whitespace around function keyword arguments.",
+                  "type": "string",
+                  "default": "none",
+                  "enum": ["none", "single", "off"]
+                },
+                "julia.format.lineends": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.ops": {
+                  "markdownDescription": "Format whitespace around operators.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.format.tuples": {
+                  "markdownDescription": "Format tuples.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.call": {
+                  "markdownDescription": "This compares call signatures against all known methods for the called function. Calls with too many or too few arguments, or unknown keyword parameters are highlighted.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.constif": {
+                  "markdownDescription": "Check for constant conditionals in if statements that result in branches never being reached.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.datadecl": {
+                  "markdownDescription": "Check variables used in type declarations are datatypes.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.disabledDirs": {
+                  "markdownDescription": "Specifies sub-directories in a package directory where only basic linting is. This drastically lowers the chance for false positives.",
+                  "type": "array",
+                  "default": ["docs", "test"],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "julia.lint.iter": {
+                  "markdownDescription": "Check iterator syntax of loops. Will identify, for example, attempts to iterate over single values.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.lazy": {
+                  "markdownDescription": "Check for deterministic lazy boolean operators.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.missingrefs": {
+                  "markdownDescription": "Highlight unknown symbols. The `symbols` option will not mark unknown fields.",
+                  "type": "string",
+                  "default": "all",
+                  "enum": ["none", "symbols", "all"]
+                },
+                "julia.lint.modname": {
+                  "markdownDescription": "Check submodule names do not shadow their parent's name.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.nothingcomp": {
+                  "markdownDescription": "Check for use of `==` rather than `===` when comparing against `nothing`.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.pirates": {
+                  "markdownDescription": "Check for type piracy - the overloading of external functions with methods specified for external datatypes. 'External' here refers to imported code.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.run": {
+                  "markdownDescription": "Run the linter on active files.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.typeparam": {
+                  "markdownDescription": "Check parameters declared in `where` statements or datatype declarations are used.",
+                  "type": "boolean",
+                  "default": true
+                },
+                "julia.lint.useoffuncargs": {
+                  "markdownDescription": "Check that all declared arguments are used within the function body.",
+                  "type": "boolean",
+                  "default": true
+                },
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Requires a new release of the LSP package for ST 3 first.

It would break current ("nested" style) user overrides for the language server settings, but I guess it's fine to merge since there are no releases or tags for this package yet.