### PR TITLE
Give back focus on code send

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -81,7 +81,8 @@ def send_julia_repl(window: sublime.Window, code_block: str) -> None:
         code_block += "\n"
     window.run_command("terminus_send_string", {"string": code_block, "tag": JULIA_REPL_TAG})
     # return focus to the sending window
-    window.focus_view(return_focus)
+    if return_focus:
+        window.focus_view(return_focus)
 
 
 def versioned_text_document_position_params(view: sublime.View, location: int) -> Dict[str, Any]:

--- a/plugin.py
+++ b/plugin.py
@@ -75,11 +75,13 @@ def send_julia_repl(window: sublime.Window, code_block: str) -> None:
     """
     Send a code block string to Julia REPL via Terminus package.
     """
-
+    return_focus = window.active_view()
     # ensure code block ends with newline to enforce execution in REPL
     if not code_block.endswith("\n"):
         code_block += "\n"
     window.run_command("terminus_send_string", {"string": code_block, "tag": JULIA_REPL_TAG})
+    # return focus to the sending window
+    window.focus_view(return_focus)
 
 
 def versioned_text_document_position_params(view: sublime.View, location: int) -> Dict[str, Any]:


### PR DESCRIPTION
I noticed that when using the julia REPL in a tab view, instead of the panel, the REPL tab would steal focus after every `alt+Enter`. Added a bit of code to ensure it is given back to the view making the call to `send_julia_repl`