### PR TITLE
Lists all environments in the working folders, the chose_folder_dialog now opens at the file location.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -809,9 +809,7 @@ class EnvPathInputHandler(sublime_plugin.ListInputHandler):
                     basename = os.path.basename(folder.path)
                     relpath = os.path.relpath(subdir, folder.path)
                     env_name = basename if relpath == '.' else os.path.join(basename, relpath)
-
-                    items.append(sublime.ListInputItem(
-                        env_name, folderpath, kind=KIND_WORKSPACE_FOLDER))
+                    items.append(sublime.ListInputItem(env_name, folderpath, kind=KIND_WORKSPACE_FOLDER))
 
         # Add default Julia environments from .julia/environments
         items.extend([

--- a/plugin.py
+++ b/plugin.py
@@ -743,7 +743,7 @@ class JuliaActivateEnvironmentCommand(LspWindowCommand):
             return
         env_path = kwargs.get('env_path')
         if env_path == SELECT_FOLDER_DIALOG_FLAG:
-            curr_file = self.window.active_view().file_name()
+            curr_file = self.window.active_view().file_name()  # pyright: ignore[reportOptionalMemberAccess]
             starting_dir = os.path.dirname(curr_file) if curr_file else None
             sublime.select_folder_dialog(
                 self.on_select_folder, starting_dir, multi_select=False)  # pyright: ignore[reportArgumentType]

--- a/plugin.py
+++ b/plugin.py
@@ -800,13 +800,15 @@ class EnvPathInputHandler(sublime_plugin.ListInputHandler):
         # Add all environments withing a working folder.
         for folder in self.workspace_folders:
             for subdir, dirs, files in os.walk(folder.path):
+                # exclude all hidden folders in the working folder
+                dirs[:] = [d for d in dirs if not d.startswith('.')]
+
                 folderpath = os.path.join(folder.path, subdir)
                 if folderpath not in env_paths and is_julia_environment(folderpath):
-                    if os.path.relpath(subdir, folder.path) == '.':
-                        env_name = os.path.join(os.path.basename(folder.path))
-                    else:
-                        env_name = os.path.join(os.path.basename(
-                            folder.path), os.path.relpath(subdir, folder.path))
+                    basename = os.path.basename(folder.path)
+                    relpath = os.path.relpath(subdir, folder.path)
+                    env_name = basename if relpath == '.' else os.path.join(basename, relpath)
+
                     items.append(sublime.ListInputItem(
                         env_name, folderpath, kind=KIND_WORKSPACE_FOLDER))
 

--- a/plugin.py
+++ b/plugin.py
@@ -743,7 +743,8 @@ class JuliaActivateEnvironmentCommand(LspWindowCommand):
             return
         env_path = kwargs.get('env_path')
         if env_path == SELECT_FOLDER_DIALOG_FLAG:
-            starting_dir = os.path.dirname(self.window.active_view().file_name())
+            curr_file = self.window.active_view().file_name()
+            starting_dir = os.path.dirname(curr_file) if curr_file else None
             sublime.select_folder_dialog(self.on_select_folder, starting_dir,
                                          multi_select=False)  # pyright: ignore
         elif env_path:

--- a/plugin.py
+++ b/plugin.py
@@ -745,8 +745,8 @@ class JuliaActivateEnvironmentCommand(LspWindowCommand):
         if env_path == SELECT_FOLDER_DIALOG_FLAG:
             curr_file = self.window.active_view().file_name()
             starting_dir = os.path.dirname(curr_file) if curr_file else None
-            sublime.select_folder_dialog(self.on_select_folder, starting_dir,
-                                         multi_select=False)  # pyright: ignore
+            sublime.select_folder_dialog(
+                self.on_select_folder, starting_dir, multi_select=False)  # pyright: ignore[reportArgumentType]
         elif env_path:
             self.activate_environment(env_path)
 

--- a/plugin.py
+++ b/plugin.py
@@ -803,7 +803,6 @@ class EnvPathInputHandler(sublime_plugin.ListInputHandler):
             for subdir, dirs, files in os.walk(folder.path):
                 # exclude all hidden folders in the working folder
                 dirs[:] = [d for d in dirs if not d.startswith('.')]
-
                 folderpath = os.path.join(folder.path, subdir)
                 if folderpath not in env_paths and is_julia_environment(folderpath):
                     basename = os.path.basename(folder.path)


### PR DESCRIPTION
Hi,

small PR to have all the environments in a working folder listed, so that if I have a package I am working on with other local packages with theri own environment I can switch between them easily.
Also applies for example to dedicated test environments within the same project.

Small fix: the dialog to chose a folder manually now opens in the directory of the current file