### PR TITLE
Fix minor type issues

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -337,12 +337,10 @@ class JuliaActivateEnvironmentCommand(LspWindowCommand):
     in order to provide autocomplete suggestions and diagnostics. The active environment will be shown in the status
     bar, unless the "show_environment_status" setting is disabled. """
 
-    def run(self, **kwargs) -> None:
-        files = kwargs.get('files')
+    def run(self, *, files: list[str] | None = None, env_path: str | None = None) -> None:
         if files:
             self.activate_environment(os.path.dirname(files[0]))
             return
-        env_path = kwargs.get('env_path')
         if env_path == SELECT_FOLDER_DIALOG_FLAG:
             curr_file = self.window.active_view().file_name()  # pyright: ignore[reportOptionalMemberAccess]
             starting_dir = os.path.dirname(curr_file) if curr_file else None
@@ -351,10 +349,9 @@ class JuliaActivateEnvironmentCommand(LspWindowCommand):
         elif env_path:
             self.activate_environment(env_path)
 
-    def is_visible(self, **kwargs) -> bool:
+    def is_visible(self, *, files: list[str] | None = None) -> bool:
         if not super().is_enabled():
             return False
-        files = kwargs.get('files')
         if files is not None:  # command was invoked from the side bar context menu
             return len(files) == 1 and os.path.basename(files[0]) in ('Project.toml', 'JuliaProject.toml')
         return True
@@ -643,6 +640,10 @@ class JuliaSearchDocumentationCommand(LspWindowCommand):
             self._sheet_id = sheet.id()
             if active_view and active_view.is_valid():
                 self.window.focus_view(active_view)
+
+        # This is guaranteed but it's not obvious to type-checker.
+        if not isinstance(sheet, sublime.HtmlSheet):
+            return
 
         frontmatter = mdpopups.format_frontmatter({
             "allow_code_wrap": True,

--- a/plugin.py
+++ b/plugin.py
@@ -641,10 +641,6 @@ class JuliaSearchDocumentationCommand(LspWindowCommand):
             if active_view and active_view.is_valid():
                 self.window.focus_view(active_view)
 
-        # This is guaranteed but it's not obvious to type-checker.
-        if not isinstance(sheet, sublime.HtmlSheet):
-            return
-
         frontmatter = mdpopups.format_frontmatter({
             "allow_code_wrap": True,
             "language_map": {
@@ -703,7 +699,7 @@ class JuliaSearchDocumentationCommand(LspWindowCommand):
 
         content = frontmatter + toolbar + markdown_content
 
-        mdpopups.update_html_sheet(sheet, content, css=css().sheets, wrapper_class="lsp_sheet")
+        mdpopups.update_html_sheet(sheet, content, css=css().sheets, wrapper_class="lsp_sheet")  # pyright: ignore[reportArgumentType]
 
     def input(self, args: dict) -> sublime_plugin.TextInputHandler | None:
         if "word" not in args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.pyright]
 pythonVersion = '3.8'
+typeCheckingMode = 'standard'
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
When type-checking through https://github.com/sublimelsp/lsp_maintainers some issues pop up.

The differences in what type issues are found come from the fact that there are conflicting types in LSP stubs and bundled ST types and I think the order of resolving can be different depending on type-checker configuration.

```
/usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-julia/plugin.py
  /usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-julia/plugin.py:343:55 - error: Argument of type "Literal[0]" cannot be assigned to parameter "key" of type "str" in function "__getitem__"
    "Literal[0]" is not assignable to "str" (reportArgumentType)
  /usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-julia/plugin.py:352:39 - error: Argument of type "dict[str, Any]" cannot be assigned to parameter "env_path" of type "str" in function "activate_environment"
    "dict[str, Any]" is not assignable to "str" (reportArgumentType)
  /usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-julia/plugin.py:359:57 - error: Argument of type "Literal[0]" cannot be assigned to parameter "key" of type "str" in function "__getitem__"
    "Literal[0]" is not assignable to "str" (reportArgumentType)
  /usr/local/workspace/lsp/lsp_maintainers/repositories/LSP-julia/plugin.py:705:36 - error: Argument of type "HtmlSheet | Sheet" cannot be assigned to parameter "sheet" of type "HtmlSheet" in function "update_html_sheet"
    Type "HtmlSheet | Sheet" is not assignable to type "HtmlSheet"
      "Sheet" is not assignable to "HtmlSheet" (reportArgumentType)
```